### PR TITLE
Undeclared dependency on `zope.schema`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'setuptools',
         'zope.dottedname',
         'zope.interface',
+        'zope.schema',
         'zope.exceptions >=3.7.1',  # required for extract_stack
     ],
     include_package_data=True,


### PR DESCRIPTION
Even if `mongopersist[zope]` depends on packages that depend on `zope.schema`, we should not rely on transitive dependencies, but add to `install_requires` everything we `import`.

But adding `zope.schema` to the `[zope]` `extras_require` is not enough, as `mongopersist.interfaces` imports it directly.
