### PR TITLE
Override equality to not use builtin cmp

### DIFF
--- a/src/mongopersist/serialize.py
+++ b/src/mongopersist/serialize.py
@@ -66,6 +66,12 @@ class PersistentDict(persistent.dict.PersistentDict):
         # slower. So let's not do that.
         return self.data[key]
 
+    def __eq__(self, other):
+        return self.data == other
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class PersistentList(persistent.list.PersistentList):
     _p_mongo_sub_object = True

--- a/src/mongopersist/tests/test_serialize.py
+++ b/src/mongopersist/tests/test_serialize.py
@@ -1039,6 +1039,32 @@ def doctest_deserialize_persistent_references():
     """
 
 
+def doctest_PersistentDict_equality():
+    """Test basic functions if PersistentDicts
+
+      >>> import datetime
+      >>> obj1 = serialize.PersistentDict({'key':'value'})
+      >>> obj2 = serialize.PersistentDict({'key':'value'})
+      >>> obj3 = serialize.PersistentDict({'key':None})
+      >>> obj4 = serialize.PersistentDict({'key':datetime.datetime.now()})
+
+      >>> obj1 == obj1 and obj2 == obj2 and obj3 == obj3 and obj4 == obj4
+      True
+
+      >>> obj1 == obj2
+      True
+
+      >>> obj1 == obj3
+      False
+
+      >>> obj1 == obj4
+      False
+
+      >>> obj3 == obj4
+      False
+    """
+
+
 def test_suite():
     return doctest.DocTestSuite(
         setUp=testing.setUp, tearDown=testing.tearDown,

--- a/versions.cfg
+++ b/versions.cfg
@@ -229,4 +229,4 @@ distribute = 0.6.36
 # zope.interface==4.0.2
 # zope.testing==4.1.1
 # zope.testrunner==4.0.4
-setuptools = 0.8
+setuptools = 3.3


### PR DESCRIPTION
Otherwise, comparing two PersistentDicts with "==" will raise a TypeError when builtin "cmp" fails, but should actually return False. A new test is added
